### PR TITLE
chore: enable the ruff preview for rule F822

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ target-version = "py310"
 [tool.ruff.lint]
 select = ["E", "F", "G", "B", "I", "SIM", "TID", "PL", "RUF"]
 ignore = ["E501"]
+extend-select = ["F822"]
+preview = true
+explicit-preview-rules = true
 [tool.ruff.lint.isort]
 known-first-party = ["vechord"]
 [tool.ruff.lint.pylint]


### PR DESCRIPTION
- refer to https://docs.astral.sh/ruff/rules/undefined-export/

This should be able to catch the errors like #18 