### PR TITLE
feat: support uuid v7 as primary key, add built-in tables, expose Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ in the current transaction. So users can focus on the data processing part witho
 which part of data has not been processed yet.
 
 ```python
-vr.set_pipeline([add_document, add_chunk])
-vr.run("https://paulgraham.com/best.html")  # only accept the arguments for the first function
+pipeline = vr.create_pipeline([add_document, add_chunk])
+pipeline.run("https://paulgraham.com/best.html")  # only accept the arguments for the first function
 ```
 
 ### Search
@@ -135,6 +135,12 @@ class Chunk(Table, kw_only=True):
     uid: Optional[PrimaryKeyAutoIncrease] = None
     vector: Annotated[DenseVector, VectorIndex(distance="cos", lists=128)]
     text: str
+```
+
+### Access the underlying database cursor directly
+
+```python
+vr.client.get_cursor().execute("SET vchordrq.probes = 100;")
 ```
 
 ### HTTP Service

--- a/docs/source/api.md
+++ b/docs/source/api.md
@@ -1,17 +1,24 @@
-# Interface
+# API Reference
 
 ## VechordRegistry
 
 ```{eval-rst}
 .. automodule:: vechord.registry
-   :members: VechordRegistry
+   :members: VechordRegistry, VechordPipeline
+```
+
+## VechordClient
+
+```{eval-rst}
+.. automodule:: vechord.client
+   :members: VechordClient
 ```
 
 ## Types
 
 ```{eval-rst}
 .. automodule:: vechord.spec
-   :members: Vector,ForeignKey,PrimaryKeyAutoIncrease,Table,Keyword,VectorIndex,MultiVectorIndex,KeywordIndex,IndexColumn
+   :members:
 ```
 
 ## Augment

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ ogp_image = (
 html_baseurl = "https://tensorchord.github.io/vechord/"
 html_extra_path = ["robots.txt"]
 # myst
-myst_enable_extensions = ["tasklist"]
+myst_enable_extensions = ["tasklist", "fieldlist", "colon_fence"]
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/examples/contextual.py
+++ b/examples/contextual.py
@@ -147,7 +147,7 @@ if __name__ == "__main__":
     scores = evaluate()
     print(sum(scores) / len(scores))
 
-    chunks = query_context_chunk("vector search")
-    print(chunks)
+    context_chunks = query_context_chunk("vector search")
+    print(context_chunks)
 
     vr.clear_storage()

--- a/examples/essay.py
+++ b/examples/essay.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Annotated
 
 import httpx
@@ -37,6 +38,7 @@ class Query(Table, kw_only=True):
     vector: DenseVector
 
 
+@dataclass(frozen=True)
 class Evaluation:
     map: float
     ndcg: float

--- a/examples/hybrid.py
+++ b/examples/hybrid.py
@@ -1,5 +1,3 @@
-from typing import Annotated
-
 import httpx
 
 from vechord.chunk import RegexChunker
@@ -7,51 +5,37 @@ from vechord.embedding import GeminiDenseEmbedding
 from vechord.extract import SimpleExtractor
 from vechord.registry import VechordRegistry
 from vechord.rerank import CohereReranker
-from vechord.spec import ForeignKey, Keyword, PrimaryKeyAutoIncrease, Table, Vector
+from vechord.spec import DefaultDocument, Keyword, create_chunk_with_dim
 
 URL = "https://paulgraham.com/{}.html"
-DenseVector = Vector[768]
+Chunk = create_chunk_with_dim(768)
 emb = GeminiDenseEmbedding()
 chunker = RegexChunker(size=1024, overlap=0)
 reranker = CohereReranker()
 extractor = SimpleExtractor()
 
 
-class Document(Table, kw_only=True):
-    uid: PrimaryKeyAutoIncrease | None = None
-    title: str = ""
-    text: str
-
-
-class Chunk(Table, kw_only=True):
-    uid: PrimaryKeyAutoIncrease | None = None
-    doc_id: Annotated[int, ForeignKey[Document.uid]]
-    text: str
-    vector: DenseVector
-    keyword: Keyword
-
-
 vr = VechordRegistry("hybrid", "postgresql://postgres:postgres@172.17.0.1:5432/")
-vr.register([Document, Chunk])
+vr.register([DefaultDocument, Chunk])
 
 
-@vr.inject(output=Document)
-def load_document(title: str) -> Document:
+@vr.inject(output=DefaultDocument)
+def load_document(title: str) -> DefaultDocument:
     with httpx.Client() as client:
         resp = client.get(URL.format(title))
         if resp.is_error:
             raise RuntimeError(f"Failed to fetch the document `{title}`")
-        return Document(title=title, text=extractor.extract_html(resp.text))
+        return DefaultDocument(title=title, text=extractor.extract_html(resp.text))
 
 
-@vr.inject(input=Document, output=Chunk)
+@vr.inject(input=DefaultDocument, output=Chunk)
 def chunk_document(uid: int, text: str) -> list[Chunk]:
     chunks = chunker.segment(text)
     return [
         Chunk(
             doc_id=uid,
             text=chunk,
-            vector=emb.vectorize_chunk(chunk),
+            vec=emb.vectorize_chunk(chunk),
             keyword=Keyword(chunk),
         )
         for chunk in chunks

--- a/examples/web.py
+++ b/examples/web.py
@@ -61,8 +61,8 @@ def chunk_document(uid: int, text: str) -> list[Chunk]:
 
 if __name__ == "__main__":
     # this pipeline will be used in the web app, or you can run it with `vr.run()`
-    vr.set_pipeline([load_document, chunk_document])
-    app = create_web_app(vr)
+    pipeline = vr.create_pipeline([load_document, chunk_document])
+    app = create_web_app(vr, pipeline)
 
     from wsgiref.simple_server import make_server
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pypdfium2>=4.30.1",
     "pytrec-eval-terrier>=0.5.6",
     "rich>=13.9.4",
+    "uuid-utils>=0.10.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2295,6 +2295,33 @@ wheels = [
 ]
 
 [[package]]
+name = "uuid-utils"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/0a/cbdb2eb4845dafeb632d02a18f47b02f87f2ce4f25266f5e3c017976ce89/uuid_utils-0.10.0.tar.gz", hash = "sha256:5db0e1890e8f008657ffe6ded4d9459af724ab114cfe82af1557c87545301539", size = 18828 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/54/9d22fa16b19e5d1676eba510f08a9c458d96e2a62ff2c8ebad64251afb18/uuid_utils-0.10.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:8d5a4508feefec62456cd6a41bcdde458d56827d908f226803b886d22a3d5e63", size = 573006 },
+    { url = "https://files.pythonhosted.org/packages/08/8e/f895c6e52aa603e521fbc13b8626ba5dd99b6e2f5a55aa96ba5b232f4c53/uuid_utils-0.10.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dbefc2b9113f9dfe56bdae58301a2b3c53792221410d422826f3d1e3e6555fe7", size = 292543 },
+    { url = "https://files.pythonhosted.org/packages/b6/58/cc4834f377a5e97d6e184408ad96d13042308de56643b6e24afe1f6f34df/uuid_utils-0.10.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffc49c33edf87d1ec8112a9b43e4cf55326877716f929c165a2cc307d31c73d5", size = 323340 },
+    { url = "https://files.pythonhosted.org/packages/37/e3/6aeddf148f6a7dd7759621b000e8c85382ec83f52ae79b60842d1dc3ab6b/uuid_utils-0.10.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0636b6208f69d5a4e629707ad2a89a04dfa8d1023e1999181f6830646ca048a1", size = 329653 },
+    { url = "https://files.pythonhosted.org/packages/0c/00/dd6c2164ace70b7b1671d9129267df331481d7d1e5f9c5e6a564f07953f6/uuid_utils-0.10.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc06452856b724df9dedfc161c3582199547da54aeb81915ec2ed54f92d19b0", size = 365471 },
+    { url = "https://files.pythonhosted.org/packages/b4/e7/0ab8080fcae5462a7b5e555c1cef3d63457baffb97a59b9bc7b005a3ecb1/uuid_utils-0.10.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:263b2589111c61decdd74a762e8f850c9e4386fb78d2cf7cb4dfc537054cda1b", size = 325844 },
+    { url = "https://files.pythonhosted.org/packages/73/39/52d94e9ef75b03f44b39ffc6ac3167e93e74ef4d010a93d25589d9f48540/uuid_utils-0.10.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a558db48b7096de6b4d2d2210d82bba8586a6d55f99106b03bb7d01dc5c5bcd6", size = 344389 },
+    { url = "https://files.pythonhosted.org/packages/7c/29/4824566f62666238290d99c62a58e4ab2a8b9cf2eccf94cebd9b3359131e/uuid_utils-0.10.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:807465067f3c892514230326ac71a79b28a8dfe2c88ecd2d5675fc844f3c76b5", size = 510078 },
+    { url = "https://files.pythonhosted.org/packages/5e/8f/bbcc7130d652462c685f0d3bd26bb214b754215b476340885a4cb50fb89a/uuid_utils-0.10.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:57423d4a2b9d7b916de6dbd75ba85465a28f9578a89a97f7d3e098d9aa4e5d4a", size = 515937 },
+    { url = "https://files.pythonhosted.org/packages/23/f8/34e0c00f5f188604d336713e6a020fcf53b10998e8ab24735a39ab076740/uuid_utils-0.10.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:76d8d660f18ff6b767e319b1b5f927350cd92eafa4831d7ef5b57fdd1d91f974", size = 494111 },
+    { url = "https://files.pythonhosted.org/packages/1a/52/b7f0066cc90a7a9c28d54061ed195cd617fde822e5d6ac3ccc88509c3c44/uuid_utils-0.10.0-cp39-abi3-win32.whl", hash = "sha256:6c11a71489338837db0b902b75e1ba7618d5d29f05fde4f68b3f909177dbc226", size = 173520 },
+    { url = "https://files.pythonhosted.org/packages/8b/15/f04f58094674d333974243fb45d2c740cf4b79186fb707168e57943c84a3/uuid_utils-0.10.0-cp39-abi3-win_amd64.whl", hash = "sha256:11c55ae64f6c0a7a0c741deae8ca2a4eaa11e9c09dbb7bec2099635696034cf7", size = 182965 },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/8f3288797487c82981134732dee13b1ad12082890905476f95994ce49e0f/uuid_utils-0.10.0-pp310-pypy310_pp73-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:acea543dfc7b87df749e3e814c54ac739a82ff5e3800d25bd25a3e00599e1554", size = 573053 },
+    { url = "https://files.pythonhosted.org/packages/91/28/0eb5190aa39547015d60ce5453cfd37c4d87a48d25026d72044c20cad4fc/uuid_utils-0.10.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0767eefa7b1e96f06cfa9b95758d286240c01bbf19e9d8f1b6043cdbe76cc639", size = 292596 },
+    { url = "https://files.pythonhosted.org/packages/e4/27/a451725d5df0db8baaa84adde94bbac4a33c3816a5215740c3f1dbdc46d3/uuid_utils-0.10.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:973fe4bb5258fd2ccb144d8b40c2d3158f16cc856a20527f8b40d14b2ae1dee9", size = 323414 },
+    { url = "https://files.pythonhosted.org/packages/22/6b/0edc2ad855cbe07ffd891ec636c6ff57ae3a56cdf0e90467b2edbe5b7b43/uuid_utils-0.10.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71b8505b67a0d77d0fbd765d8463094a8f447677125da7647bec7ea0b99406f0", size = 329720 },
+    { url = "https://files.pythonhosted.org/packages/4b/1d/f73af741d9a4d3168704235ef06fbda823bf2ecf551ac29caa8d7cf8ea2a/uuid_utils-0.10.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6bdcb1211bb61476cbef12a87101fa48243e20ed82b2bd324c816b1b5826bd5e", size = 365545 },
+    { url = "https://files.pythonhosted.org/packages/b1/06/92104c8ea66a6d645f00520222a52c4b91a444c2c30201ff0036dedfb8da/uuid_utils-0.10.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c5247f1df040aae71ea313819b563debe69bca7086a2cc6a3ac0eaddd3dadac", size = 325920 },
+    { url = "https://files.pythonhosted.org/packages/94/fe/0710e28b94f2311b40757dc43513290134cb4579f79981127c58640d736c/uuid_utils-0.10.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a50bd29ef89660b93aa07ffa95ac691a0e12832375030569a8bd5c9272f3b8e6", size = 344458 },
+]
+
+[[package]]
 name = "vechord"
 source = { editable = "." }
 dependencies = [
@@ -2309,6 +2336,7 @@ dependencies = [
     { name = "pypdfium2" },
     { name = "pytrec-eval-terrier" },
     { name = "rich" },
+    { name = "uuid-utils" },
 ]
 
 [package.optional-dependencies]
@@ -2366,6 +2394,7 @@ requires-dist = [
     { name = "pytrec-eval-terrier", specifier = ">=0.5.6" },
     { name = "rich", specifier = ">=13.9.4" },
     { name = "spacy", marker = "extra == 'spacy'", specifier = ">=3.8.4" },
+    { name = "uuid-utils", specifier = ">=0.10.0" },
     { name = "wordllama", marker = "extra == 'wordllama'", specifier = ">=0.3.8.post20" },
 ]
 provides-extras = ["gemini", "openai", "spacy", "wordllama", "cohere"]

--- a/vechord/__init__.py
+++ b/vechord/__init__.py
@@ -1,6 +1,6 @@
 from vechord.augment import GeminiAugmenter
 from vechord.chunk import GeminiChunker, RegexChunker, SpacyChunker, WordLlamaChunker
-from vechord.client import VectorChordClient
+from vechord.client import VechordClient
 from vechord.embedding import (
     GeminiDenseEmbedding,
     OpenAIDenseEmbedding,
@@ -10,7 +10,7 @@ from vechord.evaluate import GeminiEvaluator
 from vechord.extract import GeminiExtractor, SimpleExtractor
 from vechord.load import LocalLoader
 from vechord.model import Document
-from vechord.registry import VechordRegistry
+from vechord.registry import VechordPipeline, VechordRegistry
 from vechord.rerank import CohereReranker
 from vechord.service import create_web_app
 from vechord.spec import (
@@ -46,9 +46,10 @@ __all__ = [
     "SpacyChunker",
     "SpacyDenseEmbedding",
     "Table",
+    "VechordClient",
+    "VechordPipeline",
     "VechordRegistry",
     "Vector",
-    "VectorChordClient",
     "VectorIndex",
     "WordLlamaChunker",
     "create_web_app",

--- a/vechord/embedding.py
+++ b/vechord/embedding.py
@@ -124,7 +124,9 @@ class OpenAIDenseEmbedding(BaseEmbedding):
         )
 
 
-class SpladePPSparseEmbedding(BaseEmbedding):
+class SpladePPSparseEmbedding:
+    """Splade++ Sparse Embedding."""
+
     def __init__(self, url: str, dim: int = 30522, timeout_sec: int = 10):
         import httpx
 

--- a/vechord/extract.py
+++ b/vechord/extract.py
@@ -16,7 +16,7 @@ class BaseHTMLParser(HTMLParser):
 
     def __init__(self, *, convert_charrefs: bool = ...) -> None:
         super().__init__(convert_charrefs=convert_charrefs)
-        self.content = []
+        self.content: list[str] = []
         self.skip = False
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:

--- a/vechord/rerank.py
+++ b/vechord/rerank.py
@@ -6,7 +6,7 @@ from vechord.spec import Table
 
 class BaseReranker(ABC):
     @abstractmethod
-    def rerank(self, query: str, chunks: list[str]) -> list[str]:
+    def rerank(self, query: str, chunks: list[str]) -> list[int]:
         """Return the indices of the reranked chunks."""
         raise NotImplementedError
 
@@ -43,8 +43,8 @@ class ReciprocalRankFusion:
         chunk_map: dict[str, Table] = {}
         for chunks in retrieved_chunks:
             for i, chunk in enumerate(chunks):
-                chunk_score[chunk.uid] += self.get_score(i)
-                chunk_map[chunk.uid] = chunk
+                chunk_score[getattr(chunk, chunk.primary_key())] += self.get_score(i)
+                chunk_map[getattr(chunk, chunk.primary_key())] = chunk
 
         sorted_uid = sorted(chunk_score, key=lambda x: chunk_score[x], reverse=True)
         return [chunk_map[uid] for uid in sorted_uid]


### PR DESCRIPTION
- fix #20 
- fix #21 

changes:

- `VechordPipeline` can be created by `vr.create_pipeline` or `__init__(client)`.
- README: use the `cursor` to configure the `vchordrq.probes`
- new types: `DefaultDocument` and `create_chunk_with_dim`
- fix some type hints