### PR TITLE
fix: copy with binary format

### DIFF
--- a/examples/web.py
+++ b/examples/web.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+from datetime import datetime, timezone
+from functools import partial
 from typing import Annotated
 
 import httpx
@@ -27,7 +28,9 @@ class Document(Table, kw_only=True):
     uid: PrimaryKeyAutoIncrease | None = None
     title: str = ""
     text: str
-    updated_at: datetime = msgspec.field(default_factory=datetime.now)
+    updated_at: datetime = msgspec.field(
+        default_factory=partial(datetime.now, timezone.utc)
+    )
 
 
 class Chunk(Table, kw_only=True):

--- a/vechord/client.py
+++ b/vechord/client.py
@@ -196,7 +196,7 @@ class VechordClient:
             values,
         )
 
-    def copy_bulk(self, name: str, values: Sequence[dict]):
+    def copy_bulk(self, name: str, values: Sequence[dict], types: Sequence[str]):
         columns = sql.SQL(", ").join(map(sql.Identifier, values[0]))
         with self.transaction():
             cursor = self.get_cursor()
@@ -208,6 +208,7 @@ class VechordClient:
                     columns=columns,
                 )
             ) as copy:
+                copy.set_types(types=types)
                 for value in values:
                     copy.write_row(tuple(value.values()))
 

--- a/vechord/registry.py
+++ b/vechord/registry.py
@@ -319,7 +319,10 @@ class VechordRegistry:
             raise ValueError(f"not all the objects are {cls}")
 
         name = objs[0].name()
-        self.client.copy_bulk(name, [obj.todict() for obj in objs])
+        values = [obj.todict() for obj in objs]
+        keys = set(values[0].keys())
+        types = (v for k, v in objs[0].table_psql_types() if k in keys)
+        self.client.copy_bulk(name, values, types)
 
     def inject(
         self, input: Optional[type[Table]] = None, output: Optional[type[Table]] = None


### PR DESCRIPTION
PostgreSQL cannot apply cast rules when using COPY in BINARY mode.

Need to set the column type explicitly.


- https://www.psycopg.org/psycopg3/docs/basic/copy.html#binary-copy
- https://www.postgresql.org/docs/current/datatype.html#DATATYPE-TABLE