### PR TITLE
fix: pad the defaults to match the length of fields

### DIFF
--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -98,6 +98,32 @@ def test_table_todict():
     assert values["keyword"] == "hello"
     assert values["uid"], values
 
+    # len(__struct_fields__) == len(__struct_defaults__)
+    title = "Test Document"
+    text = "This is a test document."
+    doc = DefaultDocument(title=title, text=text)
+    assert len(DefaultDocument.fields()) == len(DefaultDocument.__struct_defaults__)
+    doc_value = doc.todict()
+
+    assert len(doc_value) == len(DefaultDocument.fields())
+    assert doc_value["uid"]
+    assert doc_value["title"] == title
+    assert doc_value["text"] == text
+    assert doc_value["created_at"]
+
+    # len(__struct_fields__) != len(__struct_defaults__)
+    class ReDocument(DefaultDocument):
+        title: str
+
+    doc = ReDocument(title=title, text=text)
+    assert len(ReDocument.fields()) == len(ReDocument.__struct_defaults__) + 1
+    doc_value = doc.todict()
+    assert len(doc_value) == len(ReDocument.fields())
+    assert doc_value["uid"]
+    assert doc_value["title"] == title
+    assert doc_value["text"] == text
+    assert doc_value["created_at"]
+
 
 def test_default_chunk():
     dim = 1024

--- a/vechord/pipeline.py
+++ b/vechord/pipeline.py
@@ -299,7 +299,7 @@ class DynamicPipeline(msgspec.Struct, kw_only=True):
                 rels.extend(conv_rels)
             else:
                 raise RequestError(
-                    f"No OCR provider for input type: {request.input_type}"
+                    f"No OCR or Graph provider for input type: {request.input_type}"
                 )
 
             if self.chunk:

--- a/vechord/spec.py
+++ b/vechord/spec.py
@@ -635,8 +635,13 @@ class Table(Storage):
                 if v is not msgspec.UNSET
             }
         # ignore default values
+        # `msgspec` use `NODEFAULT` to fill in the blank when [TODO: cases].
+        # Otherwise, there is an offset for the defaults, so we need to pad from
+        # the front.
+        if len(defaults) < len(fields):
+            defaults = (len(fields) - len(defaults)) * (msgspec.NODEFAULT,) + defaults
         res = {}
-        for k, d in zip(fields, defaults, strict=False):
+        for k, d in zip(fields, defaults, strict=True):
             v = getattr(self, k)
             if v is not msgspec.UNSET and (d is msgspec.NODEFAULT or v is not d):
                 res[k] = v
@@ -683,7 +688,7 @@ def create_chunk_with_dim(dim: int) -> Type[_DefaultChunk]:
 
     DenseVector = Vector[dim]
 
-    class DefaultChunk(_DefaultChunk):
+    class DefaultChunk(_DefaultChunk, kw_only=True):
         """A chunk table class with a specific vector dimension."""
 
         vec: DenseVector  # type: ignore


### PR DESCRIPTION
Fix the bug when the `__struct_fields__` length does not match the `__struct_defaults__` length. Add tests.

Suppress the UniqueViolation error when creating new tables or indexes.